### PR TITLE
fix test errors after pull18

### DIFF
--- a/lib/svg-icon.component.ts
+++ b/lib/svg-icon.component.ts
@@ -28,7 +28,9 @@ export class SvgIconComponent implements OnInit, OnDestroy {
 	}
 
 	ngOnDestroy() {
-		this.icnSub.unsubscribe();
+		if (this.icnSub) {
+			this.icnSub.unsubscribe();
+		}
 	}
 
 	private setSvg(svg:SVGElement) {


### PR DESCRIPTION
Hi,
After I updated, I got this error in my angular project running tests:
`ERROR: 'Error during cleanup of component', AppComponent{translate: TranslateService{store: TranslateStore{currentLang: ..., translations: ..., langs: ..., onTranslationChange: ..., on
LangChange: ..., onDefaultLangChange: ...}, currentLoader: LocalizationHttpLoader{localizationService: ...}, parser: TranslateDefaultParser{templateMatcher: ...}, missingTranslationHan
dler: FakeMissingTranslationHandler{}, isolate: false, pending: false, _onTranslationChange: EventEmitter{_isScalar: ..., observers: ..., closed: ..., isStopped: ..., hasError: ..., th
rownError: ..., __isAsync: ...}, _onLangChange: EventEmitter{_isScalar: ..., observers: ..., closed: ..., isStopped: ..., hasError: ..., thrownError: ..., __isAsync: ...}, _onDefaultLa
ngChange: EventEmitter{_isScalar: ..., observers: ..., closed: ..., isStopped: ..., hasError: ..., thrownError: ..., __isAsync: ...}, _langs: [], _translations: Object{}, _translationR
equests: Object{}}, store: Store{_isScalar: false, _dispatcher: Dispatcher{_isScalar: ..., observers: ..., closed: ..., isStopped: ..., hasError: ..., thrownError: ..., _value: ...}, _
reducer: Reducer{_isScalar: ..., observers: ..., closed: ..., isStopped: ..., hasError: ..., thrownError: ..., _value: ..., _dispatcher: ...}, select: function () { ... }, source: Stat
e{_isScalar: ..., observers: ..., closed: ..., isStopped: ..., hasError: ..., thrownError: ..., _value: ...}}, runConfig: Object{config: function () { ... }}, localizationService: Loca
lizationService{http: Http{_backend: ..., _defaultOptions: ...}, runConfig: Object{config: ...}, url: 'undefined/localizations/', requestOptions: BaseRequestOptions{method: ..., header
s: ..., body: ..., url: ..., params: ..., withCredentials: ..., responseType: ...}}}`


This fixed it for me:
`ngOnDestroy() {
		if (this.icnSub) {
			this.icnSub.unsubscribe();
		}
	}`

I guess it had something to do how the tests created and then destroys a component, so ngOnDestroy was called without an active subscription and it failed. Tests were still OK but I got this error in the logs.
