### PR TITLE
Fix #62 use private document for Universal

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2018 David Czeck.
+Copyright (c) 2019 David Czeck.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ More complex styling can be applied to the svg, for example:
 
 The following attributes can be set on svg-icon:
 - **src** - The path to SVG.
-- **name** - The name of SVG, under which it was loaded via SvgIconRegistryService.
+- **name** - An optional name of SVG, under which it was loaded via SvgIconRegistryService.
 - **[svgStyle]** - Styles to be applied to the SVG, this is based on the familiar [ngStyle].
 - **[stretch]** - A boolean (default is false) that, when true, sets `preserveAspectRatio="none"` on the SVG. This is useful for setting both the height and width styles to strech *or* distort the svg.
 

--- a/lib/package.json
+++ b/lib/package.json
@@ -2,7 +2,7 @@
   "$schema": "../../node_modules/ng-packagr/package.schema.json",
   "name": "angular-svg-icon",
   "description": "Angular 6+ component for inlining SVGs allowing them to be easily styled with CSS.",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/czeckd/angular-svg-icon.git"

--- a/lib/src/svg-icon-registry.service.ts
+++ b/lib/src/svg-icon-registry.service.ts
@@ -51,7 +51,7 @@ export class SvgIconRegistryService {
 		}
 		const o = <Observable<SVGElement>> this.http.get(url, { responseType: 'text' }).pipe(
 			map(svg => {
-				const div = document.createElement('DIV');
+				const div = this.document.createElement('DIV');
 				div.innerHTML = svg;
 				return <SVGElement>div.querySelector('svg');
 			}),

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-svg-icon",
   "description": "Angular 6+ component for inlining SVGs allowing them to be easily styled with CSS.",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/czeckd/angular-svg-icon.git"
@@ -23,13 +23,13 @@
     "lite": "lite-server"
   },
   "devDependencies": {
-    "@angular/common": "^7.1.0",
-    "@angular/compiler": "^7.1.0",
-    "@angular/compiler-cli": "^7.1.0",
-    "@angular/core": "^7.1.0",
-    "@angular/forms": "^7.1.0",
-    "@angular/platform-browser": "^7.1.0",
-    "@angular/platform-browser-dynamic": "^7.1.0",
+    "@angular/common": "^7.2.0",
+    "@angular/compiler": "^7.2.0",
+    "@angular/compiler-cli": "^7.2.0",
+    "@angular/core": "^7.2.0",
+    "@angular/forms": "^7.2.0",
+    "@angular/platform-browser": "^7.2.0",
+    "@angular/platform-browser-dynamic": "^7.2.0",
     "@types/node": "~8.9.4",
     "codelyzer": "^4.3.0",
     "concurrently": "^2.2.0",
@@ -43,7 +43,7 @@
     "ts-node": "~5.0.1",
     "tsickle": "^0.34.0",
     "tslint": "~5.9.1",
-    "typescript": "~3.1.6",
+    "typescript": "~3.2.2",
     "zone.js": "^0.8.26"
   }
 }


### PR DESCRIPTION
Merge of pull-request for adding icon name overwrote using this.document with just document, so reverting to use this.document. Updating copyright date on license and @angular version.