### PR TITLE
Add support for custom loaders

### DIFF
--- a/lib/src/angular-svg-icon.module.ts
+++ b/lib/src/angular-svg-icon.module.ts
@@ -1,17 +1,31 @@
-import { NgModule } from '@angular/core';
+import { ModuleWithProviders, NgModule, Provider } from '@angular/core';
 import { CommonModule } from '@angular/common';
-
 
 import { SVG_ICON_REGISTRY_PROVIDER } from './svg-icon-registry.service';
 import { SvgIconComponent } from './svg-icon.component';
+import { SvgHttpLoader, SvgLoader } from './svg-loader';
+
+export interface AngularSvgIconConfig {
+	loader?: Provider;
+}
 
 @NgModule({
 	imports:	  [
 		CommonModule,
 	],
 	declarations: [ SvgIconComponent ],
-	providers:    [ SVG_ICON_REGISTRY_PROVIDER ],
+	providers:    [ SVG_ICON_REGISTRY_PROVIDER, { provide: SvgLoader, useClass: SvgHttpLoader } ],
 	exports:      [ SvgIconComponent ]
 })
+export class AngularSvgIconModule {
 
-export class AngularSvgIconModule {}
+	static forRoot(config: AngularSvgIconConfig = {}): ModuleWithProviders {
+		return {
+			ngModule: AngularSvgIconModule,
+			providers: [
+				config.loader || { provide: SvgLoader, useClass: SvgHttpLoader },
+				SVG_ICON_REGISTRY_PROVIDER
+			]
+		}
+	}
+}

--- a/lib/src/svg-loader.ts
+++ b/lib/src/svg-loader.ts
@@ -1,0 +1,19 @@
+import { Observable } from 'rxjs';
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+export abstract class SvgLoader {
+	abstract getSvg(url: string): Observable<string>;
+}
+
+@Injectable()
+export class SvgHttpLoader extends SvgLoader {
+
+	constructor(private http: HttpClient) {
+		super();
+	}
+
+	getSvg(url: string): Observable<string> {
+		return this.http.get(url, { responseType: 'text' });
+	}
+}


### PR DESCRIPTION
Currently, Universal server-side compilation only works when there's actually a webserver running serving the SVG assets during build time. 

Since usually that's not the case, and newly added icons won't be already deployed on that server anyway, we introduce a loader that can retrieve the SVGs from the file system when rendering on server side.

This PR is backwards-compatible, i.e. it won't break current code. However, instead of just providing the `AngularSvgIconModule` to the app, you can now also use `AngularSvgIconModule.forRoot()` which takes in a loader. How that works, along with examples, is documented in the README.

Code-wise we introduce an `SvgLoader` interface that the service will use instead of `HttpClient`. In case none is provided, the default `SvgHttpLoader` is used.

The actual changes are quite minimal (5 LOC), the rest are interface declarations, additional imports, and documentation.