### PR TITLE
Add SVG loader to exports.

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,4 @@
 export * from './src/angular-svg-icon.module';
 export * from './src/svg-icon-registry.service';
 export * from './src/svg-icon.component';
-
+export * from './src/svg-loader';


### PR DESCRIPTION
In #64, I forgot to add the new `SVGLoader` class to the exports. This should fix it.

Sorry for the inconvenience!