### PR TITLE
Adds support for ChangeDetectionStrategy.OnPush

### DIFF
--- a/lib/src/svg-icon.component.ts
+++ b/lib/src/svg-icon.component.ts
@@ -1,4 +1,4 @@
-import { Component, DoCheck, ElementRef, HostBinding, Input,
+import { ChangeDetectorRef, Component, DoCheck, ElementRef, HostBinding, Input,
 	KeyValueChangeRecord, KeyValueChanges, KeyValueDiffer, KeyValueDiffers,
 	OnChanges, OnDestroy, OnInit, Renderer2, SimpleChange } from '@angular/core';
 
@@ -36,7 +36,8 @@ export class SvgIconComponent implements OnInit, OnDestroy, OnChanges, DoCheck {
 	constructor(private element: ElementRef,
 		private differs: KeyValueDiffers,
 		private renderer: Renderer2,
-		private iconReg: SvgIconRegistryService) {
+		private iconReg: SvgIconRegistryService,
+		private cdr: ChangeDetectorRef) {
 	}
 
 	ngOnInit() {
@@ -109,6 +110,8 @@ export class SvgIconComponent implements OnInit, OnDestroy, OnChanges, DoCheck {
 			this.renderer.appendChild(elem, icon);
 
 			this.stylize();
+			
+			this.cdr.markForCheck();
 		}
 	}
 


### PR DESCRIPTION
Currently the svg-icon component does not work in a component using `ChangeDetectionStrategy.OnPush` adds a manual call to `ChangeDetectorRef.markForCheck()` at the end of the `setSvg` function to make it compatible. The call is also harmless in cases where default change detection is being used.

I believe I placed the call in the right place ultimately it should be called once all changes for setting and styling the svg are complete if the call should be moved please let me know.