### PR TITLE
Update for ng9 and resolve multiple providers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 David Czeck.
+Copyright (c) 2020 David Czeck.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -15,9 +15,6 @@ This [demo](https://czeckd.github.io/angular-svg-icon/) shows this module in act
 
 ## How to use?
 
-Note: **Breaking change** as of angular-svg-icon@9.0.0, an explicit call to ``forRoot()``
-must be made on the module's import.
-
 ```
 $ npm i angular-svg-icon --save
 ```
@@ -46,12 +43,16 @@ import { AngularSvgIconModule } from 'angular-svg-icon';
 export class AppModule {}
 ```
 
+**BREAKINIG CHANGE**: as of angular-svg-icon@9.0.0, an explicit call to `forRoot()`
+must be made on the module's import.
+
 ### Use with Lazy Loading Feature Modules
 
-Recommended usage pattern is to import ``AngularSvgIconModule.forRoot`` in the root AppModule of your application.
-This will allow for one ``SvgIconRegistryService`` to be shared across all modules. If, for some reason, a lazily
-loaded module needs encapuslation of the service, then it is possible to load the 
-``AngularSvgIconModule.forRoot`` in each lazy loaded module too, but not recommended.
+Recommended usage pattern is to import `AngularSvgIconModule.forRoot()` in the root AppModule of your application.
+This will allow for one `SvgIconRegistryService` to be shared across all modules.
+If, for some reason, a lazily loaded module needs encapuslation of the service, then it is possible to load the 
+`AngularSvgIconModule.forRoot` in each lazy loaded module, but such usage precludes loading the package in the root
+AppModule.
 
 ## Usage
 Basic usage is:
@@ -79,7 +80,7 @@ The following attributes can be set on svg-icon:
 - **[stretch]** - A boolean (default is false) that, when true, sets `preserveAspectRatio="none"` on the SVG. This is useful for setting both the height and width styles to strech *or* distort the svg.
 
 Programatic interaction with the registry is also possible.
-Include the ``private iconReg:SvgIconRegistryService`` in the constructor:
+Include the `private iconReg: SvgIconRegistryService` in the constructor:
 ```typescript
 constructor(private iconReg:SvgIconRegistryService) { }
 ```
@@ -97,7 +98,7 @@ To preload a SVG file from a URL into the registry with predefined name:
 ```typescript
 {
   ...
-  this.iconReg.loadSvg('foo.svg', 'foo');
+  this.iconReg.loadSvg('foo.svg', 'foo').subscribe();
 }
 ```
 To add a SVG from a string:

--- a/README.md
+++ b/README.md
@@ -35,11 +35,20 @@ import { HttpClientModule } from '@angular/common/http';
 import { AngularSvgIconModule } from 'angular-svg-icon';
 
 @NgModule({
-  imports: [ HttpClientModule, AngularSvgIconModule ],
+  imports: [ HttpClientModule, AngularSvgIconModule.forRoot() ],
   ...
 })
 export class AppModule {}
 ```
+
+### Use with Lazy Loading Feature Modules
+
+Recommended usage pattern is to import ``AngularSvgIconModule.forRoot`` in the root AppModule of your application.
+This will allow for one ``SvgIconRegistryService`` to be shared across all modules.
+If, for some reason, a lazily loaded module needs encapuslation of the service, then it is possible to load the 
+``AngularSvgIconModule.forRoot`` in each lazy loaded module, but such usage precludes loading the package in the root
+AppModule.
+
 ## Usage
 Basic usage is:
 ```html

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ import { AngularSvgIconModule } from 'angular-svg-icon';
 export class AppModule {}
 ```
 
-**BREAKINIG CHANGE**: as of angular-svg-icon@9.0.0, an explicit call to `forRoot()`
+**BREAKING CHANGE**: as of angular-svg-icon@9.0.0, an explicit call to `forRoot()`
 must be made on the module's import.
 
 ### Use with Lazy Loading Feature Modules
@@ -51,7 +51,7 @@ must be made on the module's import.
 Recommended usage pattern is to import `AngularSvgIconModule.forRoot()` in the root AppModule of your application.
 This will allow for one `SvgIconRegistryService` to be shared across all modules.
 If, for some reason, a lazily loaded module needs encapuslation of the service, then it is possible to load the 
-`AngularSvgIconModule.forRoot` in each lazy loaded module, but such usage precludes loading the package in the root
+`AngularSvgIconModule.forRoot()` in each lazy loaded module, but such usage precludes loading the package in the root
 AppModule.
 
 ## Usage
@@ -118,7 +118,7 @@ To unload a SVG from the registry.
 }
 ```
 
-## Apply CSS
+### Apply CSS
 
 Using `[applyCss]="true"`, elements inside the svg (path, polygon, etc.) can be extended via component CSS an
 apply animations. This works even if inner elements have declared attributes.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Angular SVG Icon
 =========
 
-The **angular-svg-icon** is an Angular 8 service and component that provides a
+The **angular-svg-icon** is an Angular 9 service and component that provides a
 means to inline SVG files to allow for them to be easily styled by CSS and code.
 
 The service provides an icon registery that loads and caches a SVG indexed by
@@ -14,10 +14,15 @@ inner HTML.
 This [demo](https://czeckd.github.io/angular-svg-icon/) shows this module in action.
 
 ## How to use?
+
+Note: **Breaking change** as of angular-svg-icon@9.0.0, an explicit call to ``forRoot()``
+must be made on the module's import.
+
 ```
 $ npm i angular-svg-icon --save
 ```
 **Note on earlier versions of Angular:** 
+- For Angular 8, use angular-svg-icon@8.0.0
 - For Angular 7, use angular-svg-icon@7.2.1
 - For Angular 6, use angular-svg-icon@6.0.0
 - For Angular 4.3 through Angular 5.x, use angular-svg-icon@5.1.1
@@ -44,10 +49,9 @@ export class AppModule {}
 ### Use with Lazy Loading Feature Modules
 
 Recommended usage pattern is to import ``AngularSvgIconModule.forRoot`` in the root AppModule of your application.
-This will allow for one ``SvgIconRegistryService`` to be shared across all modules.
-If, for some reason, a lazily loaded module needs encapuslation of the service, then it is possible to load the 
-``AngularSvgIconModule.forRoot`` in each lazy loaded module, but such usage precludes loading the package in the root
-AppModule.
+This will allow for one ``SvgIconRegistryService`` to be shared across all modules. If, for some reason, a lazily
+loaded module needs encapuslation of the service, then it is possible to load the 
+``AngularSvgIconModule.forRoot`` in each lazy loaded module too, but not recommended.
 
 ## Usage
 Basic usage is:
@@ -230,13 +234,13 @@ size the SVG.
 
 ## Background
 
-The svg-icon is an Angular 2 component that allows for the continuation of the
+The svg-icon is an Angular component that allows for the continuation of the
 AngularJS method for easily inlining SVGs explained by [Ben
 Markowitz](https://www.mobomo.com/2014/09/angular-js-svg/) and others. Including
 the SVG source inline allows for the graphic to be easily styled by CSS.
 
 The technique made use of ng-include to inline the svg source into the document.
-Angular 2, however, drops the support of ng-include, so this is my work-around
+Angular 2, however, dropped the support of ng-include, so this was my work-around
 method.
 
 *Note:* The [icon

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ To preload a SVG file from a URL into the registry:
 ```typescript
 {
   ...
-  this.iconReg.loadSvg('foo.svg');
+  this.iconReg.loadSvg('foo.svg').subscribe();
 }
 ```
 To preload a SVG file from a URL into the registry with predefined name:

--- a/README.md
+++ b/README.md
@@ -77,8 +77,19 @@ The following attributes can be set on svg-icon:
 - **src** - The path to SVG.
 - **name** - An optional name of SVG, under which it was loaded via SvgIconRegistryService.
 - **[svgStyle]** - Styles to be applied to the SVG, this is based on the familiar [ngStyle].
-- **[stretch]** - A boolean (default is false) that, when true, sets `preserveAspectRatio="none"` on the SVG. This is useful for setting both the height and width styles to strech *or* distort the svg.
+- **[stretch]** - A boolean (default is false) that when true, sets `preserveAspectRatio="none"` on the SVG. This is useful for setting both the height and width styles to strech *or* distort the svg.
+- **[applyCss]** - A boolean that when true, extends the css into the loaded SVG. 
 
+### Using Apply CSS
+
+Using `[applyCss]="true"`, elements inside the svg (path, polygon, etc.) can be extended via component CSS an
+apply animations. This works even if inner elements have declared attributes.
+
+```html
+<svg-icon [applyCss]="true" src="images/multi_path.svg" class="multi-path-svg animated"></svg-icon>
+```
+
+### Using the Svg-Icon Registry
 Programatic interaction with the registry is also possible.
 Include the `private iconReg: SvgIconRegistryService` in the constructor:
 ```typescript
@@ -116,15 +127,6 @@ To unload a SVG from the registry.
   ...
   this.iconReg.unloadSvg('foo.svg');
 }
-```
-
-### Apply CSS
-
-Using `[applyCss]="true"`, elements inside the svg (path, polygon, etc.) can be extended via component CSS an
-apply animations. This works even if inner elements have declared attributes.
-
-```html
-<svg-icon [applyCss]="true" src="images/multi_path.svg" class="multi-path-svg animated"></svg-icon>
 ```
 
 ## Usage with Angular Universal

--- a/angular.json
+++ b/angular.json
@@ -41,7 +41,7 @@
             "main": "src/main.ts",
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
-            "aot": false,
+            "aot": true,
             "assets": [
               "src/favicon.ico",
               "src/assets"
@@ -64,7 +64,6 @@
               "sourceMap": false,
               "extractCss": true,
               "namedChunks": false,
-              "aot": true,
               "extractLicenses": true,
               "vendorChunk": false,
               "buildOptimizer": true,
@@ -73,6 +72,10 @@
                   "type": "initial",
                   "maximumWarning": "2mb",
                   "maximumError": "5mb"
+                },
+                {
+                  "type": "anyComponentStyle",
+                  "maximumWarning": "6kb"
                 }
               ]
             }
@@ -151,7 +154,12 @@
             "tsConfig": "projects/angular-svg-icon/tsconfig.lib.json",
             "project": "projects/angular-svg-icon/ng-package.json"
           }
-        },
+        ,          "configurations": {
+            "production": {
+              "tsConfig": "projects/angular-svg-icon/tsconfig.lib.prod.json"
+            }
+          }
+},
         "test": {
           "builder": "@angular-devkit/build-angular:karma",
           "options": {

--- a/package.json
+++ b/package.json
@@ -25,24 +25,24 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "~8.0.0",
-    "@angular/common": "~8.0.0",
-    "@angular/compiler": "~8.0.0",
-    "@angular/core": "~8.0.0",
-    "@angular/forms": "~8.0.0",
-    "@angular/platform-browser": "~8.0.0",
-    "@angular/platform-browser-dynamic": "~8.0.0",
-    "@angular/router": "~8.0.0",
-    "rxjs": "~6.4.0",
+    "@angular/animations": "~8.2.14",
+    "@angular/common": "~8.2.14",
+    "@angular/compiler": "~8.2.14",
+    "@angular/core": "~8.2.14",
+    "@angular/forms": "~8.2.14",
+    "@angular/platform-browser": "~8.2.14",
+    "@angular/platform-browser-dynamic": "~8.2.14",
+    "@angular/router": "~8.2.14",
+    "rxjs": "~6.5.4",
     "tslib": "^1.9.0",
     "zone.js": "~0.9.1"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "~0.800.0",
-    "@angular-devkit/build-ng-packagr": "~0.800.6",
-    "@angular/cli": "~8.0.2",
-    "@angular/compiler-cli": "~8.0.0",
-    "@angular/language-service": "~8.0.0",
+    "@angular-devkit/build-angular": "~0.803.25",
+    "@angular-devkit/build-ng-packagr": "~0.803.25",
+    "@angular/cli": "~8.3.25",
+    "@angular/compiler-cli": "~8.2.14",
+    "@angular/language-service": "~8.2.14",
     "@types/node": "~8.9.4",
     "@types/jasmine": "~3.3.8",
     "@types/jasminewd2": "~2.0.3",
@@ -59,6 +59,6 @@
     "ts-node": "~7.0.0",
     "tsickle": "^0.35.0",
     "tslint": "~5.15.0",
-    "typescript": "~3.4.3"
+    "typescript": "~3.5.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "svg-icon",
-  "description": "Angular 8 component for inlining SVGs allowing them to be easily styled with CSS.",
-  "version": "8.0.0",
+  "description": "Angular 9 component for inlining SVGs allowing them to be easily styled with CSS.",
+  "version": "9.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/czeckd/angular-svg-icon.git"
@@ -17,7 +17,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
-    "dist": "ng build angular-svg-icon && cp README.md LICENSE ./dist/angular-svg-icon/",
+    "dist": "ng build --prod angular-svg-icon && cp README.md LICENSE ./dist/angular-svg-icon/",
     "test": "ng test --source-map=false angular-svg-icon",
     "coverage": "ng test --code-coverage angular-svg-icon",
     "lint": "ng lint",
@@ -25,28 +25,28 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "~8.2.14",
-    "@angular/common": "~8.2.14",
-    "@angular/compiler": "~8.2.14",
-    "@angular/core": "~8.2.14",
-    "@angular/forms": "~8.2.14",
-    "@angular/platform-browser": "~8.2.14",
-    "@angular/platform-browser-dynamic": "~8.2.14",
-    "@angular/router": "~8.2.14",
+    "@angular/animations": "~9.0.2",
+    "@angular/common": "~9.0.2",
+    "@angular/compiler": "~9.0.2",
+    "@angular/core": "~9.0.2",
+    "@angular/forms": "~9.0.2",
+    "@angular/platform-browser": "~9.0.2",
+    "@angular/platform-browser-dynamic": "~9.0.2",
+    "@angular/router": "~9.0.2",
     "rxjs": "~6.5.4",
-    "tslib": "^1.9.0",
-    "zone.js": "~0.9.1"
+    "tslib": "^1.10.0",
+    "zone.js": "~0.10.2"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "~0.803.25",
-    "@angular-devkit/build-ng-packagr": "~0.803.25",
-    "@angular/cli": "~8.3.25",
-    "@angular/compiler-cli": "~8.2.14",
-    "@angular/language-service": "~8.2.14",
-    "@types/node": "~8.9.4",
+    "@angular-devkit/build-angular": "~0.900.3",
+    "@angular-devkit/build-ng-packagr": "~0.900.3",
+    "@angular/cli": "~9.0.3",
+    "@angular/compiler-cli": "~9.0.2",
+    "@angular/language-service": "~9.0.2",
+    "@types/node": "^12.11.1",
     "@types/jasmine": "~3.3.8",
     "@types/jasminewd2": "~2.0.3",
-    "codelyzer": "^5.0.0",
+    "codelyzer": "^5.1.2",
     "jasmine-core": "~3.4.0",
     "jasmine-spec-reporter": "~4.2.1",
     "karma": "~4.1.0",
@@ -54,11 +54,10 @@
     "karma-coverage-istanbul-reporter": "~2.0.1",
     "karma-jasmine": "~2.0.1",
     "karma-jasmine-html-reporter": "^1.4.0",
-    "ng-packagr": "^5.1.0",
+    "ng-packagr": "^9.0.0",
     "protractor": "~5.4.0",
     "ts-node": "~7.0.0",
-    "tsickle": "^0.35.0",
     "tslint": "~5.15.0",
-    "typescript": "~3.5.3"
+    "typescript": "~3.7.5"
   }
 }

--- a/projects/angular-svg-icon/package.json
+++ b/projects/angular-svg-icon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-svg-icon",
-  "description": "Angular 8 component for inlining SVGs allowing them to be easily styled with CSS.",
-  "version": "8.0.0",
+  "description": "Angular 9 component for inlining SVGs allowing them to be easily styled with CSS.",
+  "version": "9.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/czeckd/angular-svg-icon.git"
@@ -14,8 +14,8 @@
     "icon"
   ],
   "peerDependencies": {
-    "@angular/core": ">=7.0.0",
-    "@angular/common": ">=7.0.0",
-    "rxjs": ">=6.0.0"
+    "@angular/core": ">=9.0.0",
+    "@angular/common": ">=9.0.0",
+    "rxjs": ">=6.5.0"
   }
 }

--- a/projects/angular-svg-icon/src/lib/angular-svg-icon.module.ts
+++ b/projects/angular-svg-icon/src/lib/angular-svg-icon.module.ts
@@ -1,4 +1,4 @@
-import { ModuleWithProviders, NgModule, Optional, Provider, SkipSelf } from '@angular/core';
+import { ModuleWithProviders, NgModule, Provider } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { SVG_ICON_REGISTRY_PROVIDER } from './svg-icon-registry.service';
@@ -20,13 +20,7 @@ export interface AngularSvgIconConfig {
 })
 export class AngularSvgIconModule {
 
-	constructor(@Optional() @SkipSelf() parentModule?: AngularSvgIconModule) {
-		if (parentModule) {
-			throw new Error('AngularSvgIconModule is already loaded. Import in the AppModule only.');
-		}
-	}
-
-	static forRoot(config: AngularSvgIconConfig = {}): ModuleWithProviders {
+	static forRoot(config: AngularSvgIconConfig = {}): ModuleWithProviders<AngularSvgIconModule> {
 		return {
 			ngModule: AngularSvgIconModule,
 			providers: [

--- a/projects/angular-svg-icon/src/lib/angular-svg-icon.module.ts
+++ b/projects/angular-svg-icon/src/lib/angular-svg-icon.module.ts
@@ -1,4 +1,4 @@
-import { ModuleWithProviders, NgModule, Provider } from '@angular/core';
+import { ModuleWithProviders, NgModule, Optional, Provider, SkipSelf } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { SVG_ICON_REGISTRY_PROVIDER } from './svg-icon-registry.service';
@@ -10,21 +10,28 @@ export interface AngularSvgIconConfig {
 }
 
 @NgModule({
-	imports:	  [
+	imports: [
 		CommonModule,
 	],
-	declarations: [ SvgIconComponent ],
-	providers:    [ SVG_ICON_REGISTRY_PROVIDER, { provide: SvgLoader, useClass: SvgHttpLoader } ],
-	exports:      [ SvgIconComponent ]
+	declarations: [
+		SvgIconComponent
+	],
+	exports: [ SvgIconComponent ]
 })
 export class AngularSvgIconModule {
+
+	constructor(@Optional() @SkipSelf() parentModule?: AngularSvgIconModule) {
+		if (parentModule) {
+			throw new Error('AngularSvgIconModule is already loaded. Import in the AppModule only.');
+		}
+	}
 
 	static forRoot(config: AngularSvgIconConfig = {}): ModuleWithProviders {
 		return {
 			ngModule: AngularSvgIconModule,
 			providers: [
-				config.loader || { provide: SvgLoader, useClass: SvgHttpLoader },
-				SVG_ICON_REGISTRY_PROVIDER
+				SVG_ICON_REGISTRY_PROVIDER,
+				config.loader || { provide: SvgLoader, useClass: SvgHttpLoader }
 			]
 		};
 	}

--- a/projects/angular-svg-icon/src/lib/svg-icon-registry.service.spec.ts
+++ b/projects/angular-svg-icon/src/lib/svg-icon-registry.service.spec.ts
@@ -9,8 +9,8 @@ import { SvgIconRegistryService } from './svg-icon-registry.service';
 
 describe('SvgIconRegistryService', () => {
 	let service: SvgIconRegistryService;
-	let mockSvgLoader = jasmine.createSpyObj( ['getSvg'] );
-	let serverUrl: string = 'localhost';
+	const mockSvgLoader = jasmine.createSpyObj( ['getSvg'] );
+	const serverUrl = 'localhost';
 	let document: Document;
 
 	const SVG = `<svg viewBox="0 0 5 5" xmlns="http://www.w3.org/2000/svg"><path d="M2 1 h1 v1 h1 v1 h-1 v1 h-1 v-1 h-1 v-1 h1 z" /></svg>`;
@@ -23,7 +23,7 @@ describe('SvgIconRegistryService', () => {
 			]
 		});
 
-		document = TestBed.get(DOCUMENT);
+		document = TestBed.inject(DOCUMENT);
 
 	});
 

--- a/projects/angular-svg-icon/src/lib/svg-icon.component.ts
+++ b/projects/angular-svg-icon/src/lib/svg-icon.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, DoCheck, ElementRef, HostBinding, Input,
+import { ChangeDetectorRef, Component, DoCheck, ElementRef, Input,
 	KeyValueChangeRecord, KeyValueChanges, KeyValueDiffer, KeyValueDiffers,
 	OnChanges, OnDestroy, OnInit, Renderer2, SimpleChanges } from '@angular/core';
 

--- a/projects/angular-svg-icon/src/lib/svg-loader.spec.ts
+++ b/projects/angular-svg-icon/src/lib/svg-loader.spec.ts
@@ -16,8 +16,8 @@ describe('SvgHttpLoader', () => {
 	describe('getSvg', () => {
 		it ('should return SVG',
 			inject(
-    			[ HttpTestingController, SvgHttpLoader ],
-      			( httpMock: HttpTestingController, loader: SvgHttpLoader) => {
+				[ HttpTestingController, SvgHttpLoader ],
+				( httpMock: HttpTestingController, loader: SvgHttpLoader) => {
 
 					loader.getSvg('svg').subscribe( data => {
 						expect(data).toBe(SVG);

--- a/projects/angular-svg-icon/src/test.ts
+++ b/projects/angular-svg-icon/src/test.ts
@@ -4,16 +4,16 @@ import 'zone.js/dist/zone';
 import 'zone.js/dist/zone-testing';
 import { getTestBed } from '@angular/core/testing';
 import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting
+	BrowserDynamicTestingModule,
+	platformBrowserDynamicTesting
 } from '@angular/platform-browser-dynamic/testing';
 
 declare const require: any;
 
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
+	BrowserDynamicTestingModule,
+	platformBrowserDynamicTesting()
 );
 // Then we find all the tests.
 const context = require.context('./', true, /\.spec\.ts$/);
@@ -29,10 +29,10 @@ context.keys().map(context);
  * supposing we hace the class MyService like:
  *
  * class MyService {
- *    public factor = 10;
- *    add(a: number,b:number): number{
- *      return a + b;
- *    }
+ *   public factor = 10;
+ *   add(a: number,b:number): number {
+ *     return a + b;
+ *   }
  * }
  *
  * In our test we can declare our jasmine spy this way:
@@ -43,7 +43,7 @@ context.keys().map(context);
  * but factory stills declared as number
  */
 export type Spied<T> = {
-  -readonly [Key in keyof T]: T[Key] extends ((...args: any[]) => any)
-    ? jasmine.Spy
-    : T[Key]
+	-readonly [Key in keyof T]: T[Key] extends ((...args: any[]) => any)
+		? jasmine.Spy
+		: T[Key]
 };

--- a/projects/angular-svg-icon/tsconfig.lib.json
+++ b/projects/angular-svg-icon/tsconfig.lib.json
@@ -17,7 +17,8 @@
     "strictMetadataEmit": true,
     "fullTemplateTypeCheck": true,
     "strictInjectionParameters": true,
-    "enableResourceInlining": true
+    "enableResourceInlining": true,
+    "enableIvy": false
   },
   "exclude": [
     "src/test.ts",

--- a/projects/angular-svg-icon/tsconfig.lib.json
+++ b/projects/angular-svg-icon/tsconfig.lib.json
@@ -12,13 +12,11 @@
     ]
   },
   "angularCompilerOptions": {
-    "annotateForClosureCompiler": true,
     "skipTemplateCodegen": true,
     "strictMetadataEmit": true,
     "fullTemplateTypeCheck": true,
     "strictInjectionParameters": true,
-    "enableResourceInlining": true,
-    "enableIvy": false
+    "enableResourceInlining": true
   },
   "exclude": [
     "src/test.ts",

--- a/projects/angular-svg-icon/tsconfig.lib.prod.json
+++ b/projects/angular-svg-icon/tsconfig.lib.prod.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.lib.json",
+  "angularCompilerOptions": {
+    "enableIvy": false
+  }
+}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -7,7 +7,7 @@ import { AngularSvgIconModule } from 'angular-svg-icon';
 import { DemoAppComponent } from './demo-app.component';
 
 @NgModule({
-	imports:         [ BrowserModule, FormsModule, HttpClientModule, AngularSvgIconModule ],
+	imports:         [ BrowserModule, FormsModule, HttpClientModule, AngularSvgIconModule.forRoot() ],
 	declarations:    [ DemoAppComponent ],
 	bootstrap:       [ DemoAppComponent ]
 

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -4,11 +4,11 @@
     "outDir": "./out-tsc/app",
     "types": []
   },
-  "include": [
-    "src/**/*.ts"
+  "files": [
+    "src/main.ts",
+    "src/polyfills.ts"
   ],
-  "exclude": [
-    "src/test.ts",
-    "src/**/*.spec.ts"
+  "include": [
+    "src/**/*.d.ts"
   ]
 }


### PR DESCRIPTION
* Updates documentation (resolves #90)
* Upgrades to Angular 9 (resolves #91)
* Explicitly requiring `AngularSvgIconModule.forRoot()` on module load for `SvgIconRegistryService` provider (resolves #92).