### PR TITLE
svgStyle should accept more than strings

### DIFF
--- a/projects/angular-svg-icon/src/lib/svg-icon.component.ts
+++ b/projects/angular-svg-icon/src/lib/svg-icon.component.ts
@@ -24,7 +24,7 @@ export class SvgIconComponent implements OnInit, OnDestroy, OnChanges, DoCheck {
 
 	// Adapted from ngStyle
 	@Input()
-	set svgStyle(v: {[key: string]: string }) {
+	set svgStyle(v: {[key: string]: any }) {
 		this._svgStyle = v;
 		if (!this.differ && v) {
 			this.differ = this.differs.find(v).create();
@@ -34,7 +34,7 @@ export class SvgIconComponent implements OnInit, OnDestroy, OnChanges, DoCheck {
 	private svg: SVGElement;
 	private icnSub: Subscription;
 	private differ: KeyValueDiffer<string, string|number>;
-	private _svgStyle: {[key: string]: string};
+	private _svgStyle: {[key: string]: any};
 	private loaded = false;
 
 	constructor(


### PR DESCRIPTION
[ngStyle](https://angular.io/api/common/NgStyle) is defined as: `ngStyle: { [klass: string]: any; }` but angular-svg-icon just accepted strings. Therefor the following was not possible:

```
<svg-icon [svgStyle]="{'width.px': 50}"></svg-icon>
```

I changed to to accept `any`, too. If `any` is not good it should be at least `string | number`.