### PR TITLE
fix: enable icon reloading after fetch fail

### DIFF
--- a/projects/angular-svg-icon/src/lib/svg-icon-registry.service.ts
+++ b/projects/angular-svg-icon/src/lib/svg-icon-registry.service.ts
@@ -48,12 +48,14 @@ export class SvgIconRegistryService {
 				div.innerHTML = svg;
 				return div.querySelector('svg') as SVGElement;
 			}),
-			tap (svg => this.iconsByUrl.set(name, svg) ),
+			tap(svg => {
+				this.iconsByUrl.set(name, svg);
+				this.iconsLoadingByUrl.delete(name);
+			}),
 			catchError(err => {
 				console.error(err);
 				return observableThrowError(err);
 			}),
-			finalize(() => this.iconsLoadingByUrl.delete(name) ),
 			share()
 		) as Observable<SVGElement>;
 


### PR DESCRIPTION
**Fix for Icon Loading Issue on Component Destruction**

**Context**

In my project, I encountered an issue with the library's icon-loading mechanism. The problem occurred when an icon component was destroyed while its icon request was still pending. Specifically:

- The icon-loading request was canceled when the component was destroyed (thats fine)
- But even though the icon was not successfully loaded, it was prematurely removed from `iconsLoadingByUrl`.
- This caused subsequent attempts to load the same icon to fail with the error: `No svg with name '${name}' has been loaded`.

**Solution**

To fix this, I updated the logic to ensure `iconsLoadingByUrl.delete(name)` is only called after the icon has been successfully loaded. The changes include:

- Removing the `finalize `operator, which was deleting the icon entry from `iconsLoadingByUrl` even if the loading failed.
- Moving the `iconsLoadingByUrl.delete(name)` logic into the tap operator, so it runs only after the icon has been successfully loaded and added to `iconsByUrl`.

This change resolved the issue in my project.